### PR TITLE
Update tenants.json

### DIFF
--- a/tenants.json
+++ b/tenants.json
@@ -49,6 +49,11 @@
       "name":"DCA Demo Upsert",
       "synapse_asset_view":"syn51489635",
       "config_location":"demo_upsert/dca_config.json"
+    },
+    {
+      "name":"HTAN 2",
+      "synapse_asset_view":"syn20446927",
+      "config_location":"HTAN2/dca_config.json"
     }
   ]
 }

--- a/tenants.json
+++ b/tenants.json
@@ -26,7 +26,7 @@
       "config_location":"BTC/dca_config.json"
     },
     {
-      "name":"HTAN All Projects",
+      "name":"HTAN Phase 1 All Projects",
       "synapse_asset_view":"syn20446927",
       "config_location":"HTAN/dca_config.json"
     },
@@ -51,7 +51,7 @@
       "config_location":"demo_upsert/dca_config.json"
     },
     {
-      "name":"HTAN 2",
+      "name":"HTAN Phase 2 All Projects",
       "synapse_asset_view":"syn20446927",
       "config_location":"HTAN2/dca_config.json"
     }


### PR DESCRIPTION
Add HTAN2 to tenants.json so it appears in DCA. @adamjtaylor updating this file is necessary to [add HTAN2](https://github.com/Sage-Bionetworks/data_curator_config/pull/221
). Please make sure the `name` field is what you want to see in DCA's DCC selection menu.